### PR TITLE
add option to enable jitter in retries

### DIFF
--- a/lib/wormhole/defaults.ex
+++ b/lib/wormhole/defaults.ex
@@ -3,4 +3,5 @@ defmodule Wormhole.Defaults do
   def retry_count, do: 1
   def backoff_ms,  do: 1_000
   def crush_report,  do: false
+  def jitter, do: :rand.uniform(250)
 end

--- a/lib/wormhole/retry.ex
+++ b/lib/wormhole/retry.ex
@@ -31,11 +31,19 @@ defmodule Wormhole.Retry do
 
   defp capture_response(response={:ok, _}, _, _, _) do response end
   defp capture_response(response, callback, options, retry_count) do
-    backoff_ms  = Keyword.get(options, :backoff_ms)  || Defaults.backoff_ms
+    backoff_ms  = Keyword.get(options, :backoff_ms) || Defaults.backoff_ms
+    jitter = Keyword.get(options, :jitter) && Defaults.jitter
 
     retry_count - 1
-    |> backoff(backoff_ms, response)
+    |> backoff(backoff_ms, response, jitter)
     |> call_capture(callback, options, response)
+  end
+
+  defp backoff(retry_count, backoff_ms, response, jitter=nil) do
+    backoff(retry_count, backoff_ms, response)
+  end
+  defp backoff(retry_count, backoff_ms, response, jitter) do
+    backoff(retry_count, backoff_ms + jitter, response)
   end
 
   defp backoff(retry_count=0, _backoff_ms, _response) do retry_count end

--- a/test/wormhole_test.exs
+++ b/test/wormhole_test.exs
@@ -75,6 +75,13 @@ defmodule WormholeTest do
     refute_receive({_, :foo})
   end
 
+  test "if response arived after timeout with jitter" do
+    retry_count = 3
+    options = [timeout_ms: 100, retry_count: retry_count, backoff_ms: 10, jitter: true]
+    assert Wormhole.capture(fn-> :timer.sleep 150; :foo end, options) == {:error, {:timeout, 100}}
+    refute_receive({_, :foo})
+  end
+
   def foo_function do :foo end
 
   def bar_function(arg) do {:bar, arg} end


### PR DESCRIPTION
# Description

Having a consistent retry pattern results in the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem). By adding jitter to retries you sidestep some of the problems with a consistent retry pattern. 

# How it works

 This PR introduces a new option `jitter`. When set to `true` `jitter` will be added to `backoff_ms`. 
`jitter` is generated by calling `:rand.uniform(250)`. This generates a number between `1` and `250`. 

When `jitter` is not set, no `jitter` is added to `backoff_ms`, and normal execution paths are taken.

# Tests

I've copied the `if response arived after timeout` test and added the jitter option. This ensures previous behaviour is preserved and the new execution paths are taken. 