### PR TITLE
Update to Elixir 1.7

### DIFF
--- a/lib/wormhole/callback_wrapper.ex
+++ b/lib/wormhole/callback_wrapper.ex
@@ -15,9 +15,9 @@ defmodule Wormhole.CallbackWrapper do
     try do
       callback.() |> handle_response(caller)
     rescue error ->
-      exit(exit_arg(error, stacktrace?))
+      exit(exit_arg(error, __STACKTRACE__, stacktrace?))
     catch key, error ->
-      exit(exit_arg(key, error, stacktrace?))
+      exit(exit_arg(key, error, __STACKTRACE__, stacktrace?))
     end
   end
 
@@ -33,13 +33,17 @@ defmodule Wormhole.CallbackWrapper do
 
   end
 
-  defp exit_arg(error, _stacktrace?=false), do:
+  defp exit_arg(error, _stacktrace, _stacktrace? = false) do
     {:shutdown, error}
-  defp exit_arg(error, _stacktrace?=true), do:
-    {:shutdown, {error, System.stacktrace()}}
+  end
+  defp exit_arg(error, stacktrace, _stacktrace? = true) do
+    {:shutdown, {error, stacktrace}}
+  end
 
-  defp exit_arg(key, error, _stacktrace?=false), do:
+  defp exit_arg(key, error, _stacktrace, _stacktrace? = false) do
     {:shutdown, {key, error}}
-  defp exit_arg(key, error, _stacktrace?=true), do:
-    {:shutdown, {key, error, System.stacktrace()}}
+  end
+  defp exit_arg(key, error, stacktrace,  _stacktrace? = true) do
+    {:shutdown, {key, error, stacktrace}}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Wormhole.Mixfile do
 
   defp deps do
     [
-      {:logger_file_backend, "~> 0.0.6", only: :test},
+      {:logger_file_backend, "~> 0.0.11", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Wormhole.Mixfile do
   def project do
     [app: :wormhole,
      version: "2.3.0",
-     elixir: "~> 1.4",
+     elixir: "~> 1.7",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+%{
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "logger_file_backend": {:hex, :logger_file_backend, "0.0.9", "5c2f7d4a28431e695cdf94d191523dbafe609321a67bb654254897f546c393db", [:mix], [], "hexpm"}}
+  "logger_file_backend": {:hex, :logger_file_backend, "0.0.11", "3bbc5f31d3669e8d09d7a9443e86056fae7fc18e45c6f748c33b8c79a7e147a1", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
Fixes System.stacktrace/0 deprecation mentioned in #34 
Fixes LoggerFileBackend's GenEvent deprecation warning by updating to version 0.0.11